### PR TITLE
fix: adjust warning ‘strstr’ from incompatible pointer type.

### DIFF
--- a/fricc2load/fricc2load.c
+++ b/fricc2load/fricc2load.c
@@ -84,9 +84,15 @@ ZEND_API zend_op_array *fricc2load_compile_file(zend_file_handle *file_handle, i
 	char *tmp_buf = NULL;
 	size_t tmp_size = 0;
 
-	// ignore phar
-	if (!file_handle || !file_handle->filename || strstr(file_handle->filename, ".phar") || strstr(file_handle->filename, "phar://"))
+#if PHP_VERSION_ID >= 80100
+	if (!file_handle || !file_handle->filename || strstr(ZSTR_VAL(file_handle->filename), ".phar") || strstr(ZSTR_VAL(file_handle->filename), "phar://")){
 		return org_compile_file(file_handle, type TSRMLS_CC);
+	}
+#else
+	if (!file_handle || !file_handle->filename || strstr(file_handle->filename, ".phar") || strstr(file_handle->filename, "phar://")){
+    	return org_compile_file(file_handle, type TSRMLS_CC);
+    }
+#endif
 
 	// checking file name
 	memset(fname, 0, sizeof fname);


### PR DESCRIPTION
Hello, I was compiling the extension for PHP 8.0 and the compiler was returning some warnings like below.

`
/home/marcosmarcolin/PhpstormProjects/GitHub/marcosmarcolin-fricc2load/fricc2load/fricc2load.c:88:108: warning: passing argument 1 of ‘strstr’ from incompatible pointer type [-Wincompatible-pointer-types]
   88 |  if (!file_handle || !file_handle->filename || strstr(file_handle->filename, ".phar") || strstr(file_handle->filename, "phar://"))
      |                                                                                                 ~~~~~~~~~~~^~~~~~~~~~
      |                                                                                                            |
      |                                                                                                            zend_string * {aka struct _zend_string *}
`

With that, I added a validation according to PHP 8.0.x changes, did some testing and it worked correctly.

So I submitted a PR for review.